### PR TITLE
restore ignore rest siblings

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = {
       2,
       {
         args: 'after-used',
-        ignoreRestSiblings: false,
+        ignoreRestSiblings: true,
         argsIgnorePattern: '^_',
       },
     ],
@@ -89,7 +89,7 @@ module.exports = {
           2,
           {
             args: 'after-used',
-            ignoreRestSiblings: false,
+            ignoreRestSiblings: true,
             argsIgnorePattern: '^_',
           },
         ],


### PR DESCRIPTION
The code affected would be destructuring to produce a new excluded object:
```ts
const { id, name, state, ...ownerBody } = owner;
....
someFunc(ownerBody)
```
It is not a particularly safe operation as we could accidentally pass or forget to pass some vital information. However this is largely a non issue in typescript.