### PR TITLE
add else rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,10 @@ module.exports = {
     'no-console': [2, { allow: ['error'] }],
     'max-lines': ['error', 400],
     'max-params': ['error', 2],
+    'no-dupe-else-if': 2,
+    'no-lonely-if': 2,
+    'no-duplicate-case': 2,
+    'no-else-return': [2, { allowElseIf: true }],
   },
 
   overrides: [

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = {
     'no-dupe-else-if': 2,
     'no-lonely-if': 2,
     'no-duplicate-case': 2,
-    'no-else-return': [2, { allowElseIf: true }],
+    'no-else-return': [2, { allowElseIf: false }],
   },
 
   overrides: [


### PR DESCRIPTION
Adding some rules to limit excessive or often redundant use of `else` keyword in `if` blocks.\
The added rules and their conditions can be read more about here:
- https://eslint.org/docs/latest/rules/no-duplicate-case
- https://eslint.org/docs/latest/rules/no-else-return
- https://eslint.org/docs/latest/rules/no-lonely-if
- https://eslint.org/docs/latest/rules/no-dupe-else-if