### PR TITLE
react/jsx-curly-brace-presence

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ module.exports = {
     'no-lonely-if': 2,
     'no-duplicate-case': 2,
     'no-else-return': [2, { allowElseIf: false }],
+    'react/jsx-curly-brace-presence': 2,
   },
 
   overrides: [


### PR DESCRIPTION
https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md

Rule to disallow curly braces when a plain string is passed

❌ Failing examples:
```ts
<Component stringValue={"string"} />

<Component stringValue={`plain string`} />

<div>{"some value"}</div>
```

✅ Passing examples:
```ts
<Component stringValue="string" />

<Component stringValue="plain string" />

<div>some value</div>
```