### PR TITLE
add required curly braces

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ module.exports = {
     'no-duplicate-case': 2,
     'no-else-return': [2, { allowElseIf: false }],
     'react/jsx-curly-brace-presence': 2,
+    curly: 2,
   },
 
   overrides: [


### PR DESCRIPTION
New rule that requires curly braces (`{}`) in if statements https://eslint.org/docs/latest/rules/curly

❌ Failing examples:
```ts
if (foo) foo++;

while (bar)
    baz();

if (foo) {
    baz();
} else qux();
```

✅ Passing examples:
```ts
if (foo) {
    foo++;
}

while (bar) {
    baz();
}

if (foo) {
    baz();
} else {
    qux();
}
```