### PR TITLE
no-extra-boolean-cast

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ module.exports = {
     'no-else-return': [2, { allowElseIf: false }],
     'react/jsx-curly-brace-presence': 2,
     curly: 2,
+    'no-extra-boolean-cast': 2,
   },
 
   overrides: [


### PR DESCRIPTION
Added new rule [no-extra-boolean-cast](https://eslint.org/docs/latest/rules/no-extra-boolean-cast)

❌ Failing examples:
```ts
var foo = !!!bar;

var foo = !!bar ? baz : bat;

var foo = Boolean(!!bar);

var foo = new Boolean(!!bar);

if (!!foo) {
    // ...
}

if (Boolean(foo)) {
    // ...
}

while (!!foo) {
    // ...
}

do {
    // ...
} while (Boolean(foo));

for (; !!foo; ) {
    // ...
}
```

✅ Passing examples:
```ts
var foo = !!bar;
var foo = Boolean(bar);

function qux() {
    return !!bar;
}

var foo = bar ? !!baz : !!bat;
```